### PR TITLE
Switch database

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,17 +305,38 @@ export async function up () {
     }
   ])
 }
+```
 
-export async function down () {
-  const { User } = await getModels()
-  // Write migration here
-  await User.deleteMany({ firstName: { $in: ['Jane', 'John'] } }).exec()
+## Multi-tenant
+
+```typescript
+import Migrator from "ts-migrate-mongoose";
+
+const migrator = await Migrator.connect({
+  // This is the only required property you need to set
+  // MongoDB connection string URI
+  uri: "mongodb://localhost/my-db",
+  // All the options below are optional
+  // Collection name to use for migrations (defaults to 'migrations')
+  collection: "migrations",
+  // Path to migrations directory, default is ./migrations
+  migrationsPath: "/path/to/migrations/",
+  // The template to use when creating migrations needs up and down functions exposed
+  // No need to specify unless you want to use a custom template
+  templatePath: "/path/to/template.ts",
+  // Ff making a CLI app, set this to false to prompt the user, otherwise true
+  autosync: true,
+});
+
+for (db of databases) {
+  migrator.useDb(db);
+  migrator.run("<COMMAND>");
 }
 ```
 
 ## Notes
 
-- Currently, the `-d` or `--uri`  must include the database to use for migrations in the uri.
+- Currently, the `-d` or `--uri` must include the database to use for migrations in the uri.
 - Example: `-d mongodb://localhost:27017/development`
 - If you don't want to pass it in every time feel free to use `migrate.ts` or `migrate.json` config file or an environment variable
 - Feel Free to check out the `/examples` folder in the project to get a better idea of usage in Programmatic and CLI mode

--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ export async function up () {
     }
   ])
 }
+
+export async function down () {
+  const { User } = await getModels()
+  // Write migration here
+  await User.deleteMany({ firstName: { $in: ['Jane', 'John'] } }).exec()
+}
 ```
 
 ## Multi-tenant
@@ -336,7 +342,7 @@ for (db of databases) {
 
 ## Notes
 
-- Currently, the `-d` or `--uri` must include the database to use for migrations in the uri.
+- Currently, the `-d` or `--uri`  must include the database to use for migrations in the uri.
 - Example: `-d mongodb://localhost:27017/development`
 - If you don't want to pass it in every time feel free to use `migrate.ts` or `migrate.json` config file or an environment variable
 - Feel Free to check out the `/examples` folder in the project to get a better idea of usage in Programmatic and CLI mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-migrate-mongoose",
-  "version": "3.1.8",
+  "version": "3.2.0",
   "description": "A node/typescript based migration framework for mongoose",
   "author": "Alex Eagle",
   "license": "MIT",

--- a/src/interfaces/IMigrationModule.ts
+++ b/src/interfaces/IMigrationModule.ts
@@ -1,6 +1,8 @@
+import type { Connection } from 'mongoose'
+
 interface IMigrationModule {
-  up?: () => Promise<void>
-  down?: () => Promise<void>
+  up?: (connection: Connection) => Promise<void>
+  down?: (connection: Connection) => Promise<void>
 }
 
 export default IMigrationModule

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -33,8 +33,8 @@ register(swcrc)
  * @class Migrator
  */
 class Migrator {
-  readonly migrationModel: Model<IMigration>
-  readonly connection: Connection
+  private migrationModel: Model<IMigration>
+  private connection: Connection
 
   private uri?: string
   private template: string
@@ -242,6 +242,16 @@ class Migrator {
       }
       throw error
     }
+  }
+
+  /**
+   * Switch to another database, it's recommended when you have multi-tenant databases.
+   * you can keep the same connection to change
+   * @param dbName Database name
+   */
+  useDb (dbName: string): void {
+    this.connection = this.connection.useDb(dbName)
+    this.migrationModel = getMigrationModel(this.connection, this.collection)
   }
 
   /**

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -248,10 +248,13 @@ class Migrator {
    * Switch to another database, it's recommended when you have multi-tenant databases.
    * you can keep the same connection to change
    * @param dbName Database name
+   * @param options Switch database options
+   * @see https://mongoosejs.com/docs/api/connection.html#Connection.prototype.useDb()
    */
-  useDb (dbName: string): void {
-    this.connection = this.connection.useDb(dbName)
+  useDb: Connection['useDb'] = (dbName, options) => {
+    this.connection = this.connection.useDb(dbName, options)
     this.migrationModel = getMigrationModel(this.connection, this.collection)
+    return this.connection
   }
 
   /**
@@ -426,7 +429,7 @@ class Migrator {
       }
 
       try {
-        await migrationFunction()
+        await migrationFunction(this.connection)
 
         this.logMigrationStatus(direction, migration.filename)
 

--- a/tests/migrator.test.ts
+++ b/tests/migrator.test.ts
@@ -371,11 +371,10 @@ describe('Tests for Migrator class - Programmatic approach', () => {
 
   it('should swich database', async () => {
     const migrator = await Migrator.connect({ uri })
-    migrator.useDb('db-changed')
-    expect(migrator.connection.db.databaseName).toBe('db-changed')
-
-    expect(migrator.connection.readyState).toBe(1)
+    const connection = migrator.useDb('db-changed')
+    expect(connection.db.databaseName).toBe('db-changed')
+    expect(connection.readyState).toBe(1)
     await migrator.close()
-    expect(migrator.connection.readyState).toBe(0)
+    expect(connection.readyState).toBe(0)
   })
 })

--- a/tests/migrator.test.ts
+++ b/tests/migrator.test.ts
@@ -368,4 +368,14 @@ describe('Tests for Migrator class - Programmatic approach', () => {
     await migrator.close()
     expect(migrator.connection.readyState).toBe(0)
   })
+
+  it('should swich database', async () => {
+    const migrator = await Migrator.connect({ uri })
+    migrator.useDb('db-changed')
+    expect(migrator.connection.db.databaseName).toBe('db-changed')
+
+    expect(migrator.connection.readyState).toBe(1)
+    await migrator.close()
+    expect(migrator.connection.readyState).toBe(0)
+  })
 })


### PR DESCRIPTION
switch database with same connection.

it's very useful on multi-tenant migration strategy.


```typescript
import Migrator from "ts-migrate-mongoose";

const migrator = await Migrator.connect({
  uri: "mongodb://localhost",
});

for (db of databasesToMigrate) {
  migrator.useDb(db);
  migrator.run("<COMMAND>");
}
```
