### PR TITLE
Index MigrationModel.createdAt field

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -17,7 +17,7 @@ export const getMigrationModel = (connection: Connection, collection: string): M
       enum: ['down', 'up'],
       default: 'down',
     },
-    createdAt: Date,
+    createdAt: { type: Date, index: true },
   }, {
     collection,
     autoCreate: true,


### PR DESCRIPTION
Hi,

A PR to make this library compatible with Azure Cosmos DB for mongoDB :)
 Azure Cosmos DB for mongoDB requires that when a field is used to sort results in query, this field needs to be indexed.
<img width="472" alt="image" src="https://github.com/ilovepixelart/ts-migrate-mongoose/assets/36133851/1f600036-9561-4674-a951-f644bf7b546f">

https://stackoverflow.com/questions/56988743/using-the-sort-cursor-method-without-the-default-indexing-policy-in-azure-cosm
