### PR TITLE
Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ MIGRATE_CONFIG_PATH=./migrate
 MIGRATE_MIGRATIONS_PATH=./migrations
 MIGRATE_TEMPLATE_PATH=./migrations/template.ts
 MIGRATE_AUTOSYNC=false
+# If provided, will use .env.development file, if not will use .env
+# In case you using env files, no reason to use migrate.json or migrate.ts and vice versa
+MIGRATE_MODE=development
 # or 
 migrateMongoUri=mongodb://localhost/my-db
 migrateMongoCollection=migrations
@@ -136,10 +139,12 @@ migrateConfigPath=./migrate
 migrateMigrationsPath=./migrations
 migrateTemplatePath=./migrations/template.ts
 migrateAutosync=false
+migrateMode=development
 ```
 
 | Config file          | `.env` / export          | Default      | Required | Description                                      |
 | -------------------- | ------------------------ | ------------ | -------- | ------------------------------------------------ |
+| mode                 | MIGRATE_MODE             | -            | No       | environment mode to use .env.[mode] file         |
 | uri                  | MIGRATE_MONGO_URI        | -            | Yes      | mongo connection string                          |
 | collection           | MIGRATE_MONGO_COLLECTION | migrations   | No       | collection name to use for the migrations        |
 | configPath           | MIGRATE_CONFIG_PATH      | ./migrate    | No       | path to the config file                          |
@@ -165,6 +170,7 @@ Options:
   -a, --autosync <boolean>      automatically sync new migrations without prompt (default: false)
   -m, --migrations-path <path>  path to the migration files (default: "./migrations")
   -t, --template-path <path>    template file to use when creating a migration
+  --mode <string>               environment mode to use .env.[mode] file
   -h, --help                    display help for command
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -123,23 +123,23 @@ export default {
 - `.env`
 
 ```bash
+# If provided, will use .env.development file, if not will use .env
+# In case you using env files, no reason to use migrate.json or migrate.ts and vice versa
+MIGRATE_MODE=development
 MIGRATE_MONGO_URI=mongodb://localhost/my-db
 MIGRATE_MONGO_COLLECTION=migrations
 MIGRATE_CONFIG_PATH=./migrate
 MIGRATE_MIGRATIONS_PATH=./migrations
 MIGRATE_TEMPLATE_PATH=./migrations/template.ts
 MIGRATE_AUTOSYNC=false
-# If provided, will use .env.development file, if not will use .env
-# In case you using env files, no reason to use migrate.json or migrate.ts and vice versa
-MIGRATE_MODE=development
 # or 
+migrateMode=development
 migrateMongoUri=mongodb://localhost/my-db
 migrateMongoCollection=migrations
 migrateConfigPath=./migrate
 migrateMigrationsPath=./migrations
 migrateTemplatePath=./migrations/template.ts
 migrateAutosync=false
-migrateMode=development
 ```
 
 | Config file          | `.env` / export          | Default      | Required | Description                                      |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "3.6.4",
       "license": "MIT",
       "dependencies": {
-        "@swc/core": "1.4.16",
+        "@swc/core": "1.5.3",
         "@swc/register": "0.1.10",
         "chalk": "4.1.2",
         "commander": "12.0.0",
         "dotenv": "16.4.5",
         "inquirer": "8.2.6",
-        "mongoose": "8.3.2"
+        "mongoose": "8.3.4"
       },
       "bin": {
         "migrate": "dist/cjs/bin.js"
       },
       "devDependencies": {
-        "@shelf/jest-mongodb": "4.2.0",
+        "@shelf/jest-mongodb": "4.3.1",
         "@stylistic/eslint-plugin": "1.8.0",
         "@swc/cli": "0.3.12",
         "@swc/helpers": "0.5.11",
@@ -32,7 +32,7 @@
         "@typescript-eslint/eslint-plugin": "7.8.0",
         "@typescript-eslint/parser": "7.8.0",
         "eslint": "8.57.0",
-        "eslint-plugin-jest": "28.3.0",
+        "eslint-plugin-jest": "28.5.0",
         "eslint-plugin-jest-formatting": "3.1.0",
         "eslint-plugin-sonarjs": "0.25.1",
         "jest": "29.7.0",
@@ -2952,9 +2952,9 @@
       }
     },
     "node_modules/@shelf/jest-mongodb": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-4.2.0.tgz",
-      "integrity": "sha512-AtrG0EGtoDX4/jiTHlVCtAT0QAW1RjKQDYVXK89fog07RcKr42r6hYOL+7XT/8Wj9pEmnOc1GoYQUWiOk0y8Nw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-4.3.1.tgz",
+      "integrity": "sha512-Gu67GJkct/eOzLB4mr5owPtBU/T6cR3pVe8kIFFCZRYUSXs39Gzb7CFJoGhzmKxLkJwk1A6UbUwSR0S+BCGywQ==",
       "dev": true,
       "dependencies": {
         "debug": "4.3.4",
@@ -2964,7 +2964,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "jest-environment-node": "27.x.x || 28.x || 29.x",
+        "jest-environment-node": "28.x || 29.x",
         "mongodb": "3.x.x || 4.x || 5.x || 6.x"
       }
     },
@@ -3220,9 +3220,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.16.tgz",
-      "integrity": "sha512-Xaf+UBvW6JNuV131uvSNyMXHn+bh6LyKN4tbv7tOUFQpXyz/t9YWRE04emtlUW9Y0qrm/GKFCbY8n3z6BpZbTA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.3.tgz",
+      "integrity": "sha512-pSEglypnBGLHBoBcv3aYS7IM2t2LRinubYMyP88UoFIcD2pear2CeB15CbjJ2IzuvERD0ZL/bthM7cDSR9g+aQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.2",
@@ -3236,16 +3236,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.4.16",
-        "@swc/core-darwin-x64": "1.4.16",
-        "@swc/core-linux-arm-gnueabihf": "1.4.16",
-        "@swc/core-linux-arm64-gnu": "1.4.16",
-        "@swc/core-linux-arm64-musl": "1.4.16",
-        "@swc/core-linux-x64-gnu": "1.4.16",
-        "@swc/core-linux-x64-musl": "1.4.16",
-        "@swc/core-win32-arm64-msvc": "1.4.16",
-        "@swc/core-win32-ia32-msvc": "1.4.16",
-        "@swc/core-win32-x64-msvc": "1.4.16"
+        "@swc/core-darwin-arm64": "1.5.3",
+        "@swc/core-darwin-x64": "1.5.3",
+        "@swc/core-linux-arm-gnueabihf": "1.5.3",
+        "@swc/core-linux-arm64-gnu": "1.5.3",
+        "@swc/core-linux-arm64-musl": "1.5.3",
+        "@swc/core-linux-x64-gnu": "1.5.3",
+        "@swc/core-linux-x64-musl": "1.5.3",
+        "@swc/core-win32-arm64-msvc": "1.5.3",
+        "@swc/core-win32-ia32-msvc": "1.5.3",
+        "@swc/core-win32-x64-msvc": "1.5.3"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -3257,9 +3257,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.16.tgz",
-      "integrity": "sha512-UOCcH1GvjRnnM/LWT6VCGpIk0OhHRq6v1U6QXuPt5wVsgXnXQwnf5k3sG5Cm56hQHDvhRPY6HCsHi/p0oek8oQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.3.tgz",
+      "integrity": "sha512-kRmmV2XqWegzGXvJfVVOj10OXhLgaVOOBjaX3p3Aqg7Do5ksg+bY5wi1gAN/Eul7B08Oqf7GG7WJevjDQGWPOg==",
       "cpu": [
         "arm64"
       ],
@@ -3272,9 +3272,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.16.tgz",
-      "integrity": "sha512-t3bgqFoYLWvyVtVL6KkFNCINEoOrIlyggT/kJRgi1y0aXSr0oVgcrQ4ezJpdeahZZ4N+Q6vT3ffM30yIunELNA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.3.tgz",
+      "integrity": "sha512-EYs0+ovaRw6ZN9GBr2nIeC7gUXWA0q4RYR+Og3Vo0Qgv2Mt/XudF44A2lPK9X7M3JIfu6JjnxnTuvsK1Lqojfw==",
       "cpu": [
         "x64"
       ],
@@ -3287,9 +3287,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.16.tgz",
-      "integrity": "sha512-DvHuwvEF86YvSd0lwnzVcjOTZ0jcxewIbsN0vc/0fqm9qBdMMjr9ox6VCam1n3yYeRtj4VFgrjeNFksqbUejdQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.3.tgz",
+      "integrity": "sha512-RBVUTidSf4wgPdv98VrgJ4rMzMDN/3LBWdT7l+R7mNFH+mtID7ZAhTON0o/m1HkECgAgi1xcbTOVAw1xgd5KLA==",
       "cpu": [
         "arm"
       ],
@@ -3302,9 +3302,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.16.tgz",
-      "integrity": "sha512-9Uu5YlPbyCvbidjKtYEsPpyZlu16roOZ5c2tP1vHfnU9bgf5Tz5q5VovSduNxPHx+ed2iC1b1URODHvDzbbDuQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.3.tgz",
+      "integrity": "sha512-DCC6El3MiTYfv98CShxz/g2s4Pxn6tV0mldCQ0UdRqaN2ApUn7E+zTrqaj5bk7yII3A43WhE9Mr6wNPbXUeVyg==",
       "cpu": [
         "arm64"
       ],
@@ -3317,9 +3317,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.16.tgz",
-      "integrity": "sha512-/YZq/qB1CHpeoL0eMzyqK5/tYZn/rzKoCYDviFU4uduSUIJsDJQuQA/skdqUzqbheOXKAd4mnJ1hT04RbJ8FPQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.3.tgz",
+      "integrity": "sha512-p04ysjYXEyaCGpJvwHm0T0nkPawXtdKBTThWnlh8M5jYULVNVA1YmC9azG2Avs1GDaLgBPVUgodmFYpdSupOYA==",
       "cpu": [
         "arm64"
       ],
@@ -3332,9 +3332,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.16.tgz",
-      "integrity": "sha512-UUjaW5VTngZYDcA8yQlrFmqs1tLi1TxbKlnaJwoNhel9zRQ0yG1YEVGrzTvv4YApSuIiDK18t+Ip927bwucuVQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.3.tgz",
+      "integrity": "sha512-/l4KJu0xwYm6tcVSOvF8RbXrIeIHJAhWnKvuX4ZnYKFkON968kB8Ghx+1yqBQcZf36tMzSuZUC5xBUA9u66lGA==",
       "cpu": [
         "x64"
       ],
@@ -3347,9 +3347,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.16.tgz",
-      "integrity": "sha512-aFhxPifevDTwEDKPi4eRYWzC0p/WYJeiFkkpNU5Uc7a7M5iMWPAbPFUbHesdlb9Jfqs5c07oyz86u+/HySBNPQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.3.tgz",
+      "integrity": "sha512-54DmSnrTXq4fYEKNR0nFAImG3+FxsHlQ6Tol/v3l+rxmg2K0FeeDOpH7wTXeWhMGhFlGrLIyLSnA+SzabfoDIA==",
       "cpu": [
         "x64"
       ],
@@ -3362,9 +3362,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.16.tgz",
-      "integrity": "sha512-bTD43MbhIHL2s5QgCwyleaGwl96Gk/scF2TaVKdUe4QlJCDV/YK9h5oIBAp63ckHtE8GHlH4c8dZNBiAXn4Org==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.3.tgz",
+      "integrity": "sha512-piUMqoHNwDXChBfaaFIMzYgoxepfd8Ci1uXXNVEnuiRKz3FiIcNLmvXaBD7lKUwKcnGgVziH/CrndX6SldKQNQ==",
       "cpu": [
         "arm64"
       ],
@@ -3377,9 +3377,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.16.tgz",
-      "integrity": "sha512-/lmZeAN/qV5XbK2SEvi8e2RkIg8FQNYiSA8y2/Zb4gTUMKVO5JMLH0BSWMiIKMstKDPDSxMWgwJaQHF8UMyPmQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.3.tgz",
+      "integrity": "sha512-zV5utPYBUzYhBOomCByAjKAvfVBcOCJtnszx7Zlfz7SAv/cGm8D1QzPDCvv6jDhIlUtLj6KyL8JXeFr+f95Fjw==",
       "cpu": [
         "ia32"
       ],
@@ -3392,9 +3392,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.16.tgz",
-      "integrity": "sha512-BPAfFfODWXtUu6SwaTTftDHvcbDyWBSI/oanUeRbQR5vVWkXoQ3cxLTsDluc3H74IqXS5z1Uyoe0vNo2hB1opA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.3.tgz",
+      "integrity": "sha512-QmUiXiPIV5gBADfDh8e2jKynEhyRC+dcKP/zF9y5KqDUErYzlhocLd68uYS4uIegP6AylYlmigHgcaktGEE9VQ==",
       "cpu": [
         "x64"
       ],
@@ -5377,12 +5377,12 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.3.0.tgz",
-      "integrity": "sha512-5LjCSSno8E+IUCOX4hJiIb/upPIgpkaDEcaN/40gOcw26t/5UTLHFc4JdxKjOOvGTh0XdCu+fNr0fpOVNvcxMA==",
+      "version": "28.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.5.0.tgz",
+      "integrity": "sha512-6np6DGdmNq/eBbA7HOUNV8fkfL86PYwBfwyb8n23FXgJNTR8+ot3smRHjza9LGsBBZRypK3qyF79vMjohIL8eQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "^6.0.0"
+        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
       },
       "engines": {
         "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
@@ -7710,9 +7710,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.3.2.tgz",
-      "integrity": "sha512-3JcpDjFI25cF/3xpu+4+9nM0lURQTNLcP86X83+LvuICdn453QQLmhSrUr2IPM/ffLiDE9KPl9slNb2s0hZPpg==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.3.4.tgz",
+      "integrity": "sha512-ckBaBzKgtWgCalW/LPkcBsR3wKCOYEJ9jLFPmYCYV7TLStpETY757ELx8/1stL11+6HxLLVffawBffXzd0Y7YA==",
       "dependencies": {
         "bson": "^6.5.0",
         "kareem": "2.6.3",
@@ -7720,7 +7720,7 @@
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.1"
+        "sift": "17.1.3"
       },
       "engines": {
         "node": ">=16.20.1"
@@ -8793,9 +8793,9 @@
       }
     },
     "node_modules/sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -12203,9 +12203,9 @@
       }
     },
     "@shelf/jest-mongodb": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-4.2.0.tgz",
-      "integrity": "sha512-AtrG0EGtoDX4/jiTHlVCtAT0QAW1RjKQDYVXK89fog07RcKr42r6hYOL+7XT/8Wj9pEmnOc1GoYQUWiOk0y8Nw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-4.3.1.tgz",
+      "integrity": "sha512-Gu67GJkct/eOzLB4mr5owPtBU/T6cR3pVe8kIFFCZRYUSXs39Gzb7CFJoGhzmKxLkJwk1A6UbUwSR0S+BCGywQ==",
       "dev": true,
       "requires": {
         "debug": "4.3.4",
@@ -12398,82 +12398,82 @@
       }
     },
     "@swc/core": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.16.tgz",
-      "integrity": "sha512-Xaf+UBvW6JNuV131uvSNyMXHn+bh6LyKN4tbv7tOUFQpXyz/t9YWRE04emtlUW9Y0qrm/GKFCbY8n3z6BpZbTA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.5.3.tgz",
+      "integrity": "sha512-pSEglypnBGLHBoBcv3aYS7IM2t2LRinubYMyP88UoFIcD2pear2CeB15CbjJ2IzuvERD0ZL/bthM7cDSR9g+aQ==",
       "requires": {
-        "@swc/core-darwin-arm64": "1.4.16",
-        "@swc/core-darwin-x64": "1.4.16",
-        "@swc/core-linux-arm-gnueabihf": "1.4.16",
-        "@swc/core-linux-arm64-gnu": "1.4.16",
-        "@swc/core-linux-arm64-musl": "1.4.16",
-        "@swc/core-linux-x64-gnu": "1.4.16",
-        "@swc/core-linux-x64-musl": "1.4.16",
-        "@swc/core-win32-arm64-msvc": "1.4.16",
-        "@swc/core-win32-ia32-msvc": "1.4.16",
-        "@swc/core-win32-x64-msvc": "1.4.16",
+        "@swc/core-darwin-arm64": "1.5.3",
+        "@swc/core-darwin-x64": "1.5.3",
+        "@swc/core-linux-arm-gnueabihf": "1.5.3",
+        "@swc/core-linux-arm64-gnu": "1.5.3",
+        "@swc/core-linux-arm64-musl": "1.5.3",
+        "@swc/core-linux-x64-gnu": "1.5.3",
+        "@swc/core-linux-x64-musl": "1.5.3",
+        "@swc/core-win32-arm64-msvc": "1.5.3",
+        "@swc/core-win32-ia32-msvc": "1.5.3",
+        "@swc/core-win32-x64-msvc": "1.5.3",
         "@swc/counter": "^0.1.2",
         "@swc/types": "^0.1.5"
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.16.tgz",
-      "integrity": "sha512-UOCcH1GvjRnnM/LWT6VCGpIk0OhHRq6v1U6QXuPt5wVsgXnXQwnf5k3sG5Cm56hQHDvhRPY6HCsHi/p0oek8oQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.5.3.tgz",
+      "integrity": "sha512-kRmmV2XqWegzGXvJfVVOj10OXhLgaVOOBjaX3p3Aqg7Do5ksg+bY5wi1gAN/Eul7B08Oqf7GG7WJevjDQGWPOg==",
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.16.tgz",
-      "integrity": "sha512-t3bgqFoYLWvyVtVL6KkFNCINEoOrIlyggT/kJRgi1y0aXSr0oVgcrQ4ezJpdeahZZ4N+Q6vT3ffM30yIunELNA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.5.3.tgz",
+      "integrity": "sha512-EYs0+ovaRw6ZN9GBr2nIeC7gUXWA0q4RYR+Og3Vo0Qgv2Mt/XudF44A2lPK9X7M3JIfu6JjnxnTuvsK1Lqojfw==",
       "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.16.tgz",
-      "integrity": "sha512-DvHuwvEF86YvSd0lwnzVcjOTZ0jcxewIbsN0vc/0fqm9qBdMMjr9ox6VCam1n3yYeRtj4VFgrjeNFksqbUejdQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.5.3.tgz",
+      "integrity": "sha512-RBVUTidSf4wgPdv98VrgJ4rMzMDN/3LBWdT7l+R7mNFH+mtID7ZAhTON0o/m1HkECgAgi1xcbTOVAw1xgd5KLA==",
       "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.16.tgz",
-      "integrity": "sha512-9Uu5YlPbyCvbidjKtYEsPpyZlu16roOZ5c2tP1vHfnU9bgf5Tz5q5VovSduNxPHx+ed2iC1b1URODHvDzbbDuQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.5.3.tgz",
+      "integrity": "sha512-DCC6El3MiTYfv98CShxz/g2s4Pxn6tV0mldCQ0UdRqaN2ApUn7E+zTrqaj5bk7yII3A43WhE9Mr6wNPbXUeVyg==",
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.16.tgz",
-      "integrity": "sha512-/YZq/qB1CHpeoL0eMzyqK5/tYZn/rzKoCYDviFU4uduSUIJsDJQuQA/skdqUzqbheOXKAd4mnJ1hT04RbJ8FPQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.5.3.tgz",
+      "integrity": "sha512-p04ysjYXEyaCGpJvwHm0T0nkPawXtdKBTThWnlh8M5jYULVNVA1YmC9azG2Avs1GDaLgBPVUgodmFYpdSupOYA==",
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.16.tgz",
-      "integrity": "sha512-UUjaW5VTngZYDcA8yQlrFmqs1tLi1TxbKlnaJwoNhel9zRQ0yG1YEVGrzTvv4YApSuIiDK18t+Ip927bwucuVQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.5.3.tgz",
+      "integrity": "sha512-/l4KJu0xwYm6tcVSOvF8RbXrIeIHJAhWnKvuX4ZnYKFkON968kB8Ghx+1yqBQcZf36tMzSuZUC5xBUA9u66lGA==",
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.16.tgz",
-      "integrity": "sha512-aFhxPifevDTwEDKPi4eRYWzC0p/WYJeiFkkpNU5Uc7a7M5iMWPAbPFUbHesdlb9Jfqs5c07oyz86u+/HySBNPQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.5.3.tgz",
+      "integrity": "sha512-54DmSnrTXq4fYEKNR0nFAImG3+FxsHlQ6Tol/v3l+rxmg2K0FeeDOpH7wTXeWhMGhFlGrLIyLSnA+SzabfoDIA==",
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.16.tgz",
-      "integrity": "sha512-bTD43MbhIHL2s5QgCwyleaGwl96Gk/scF2TaVKdUe4QlJCDV/YK9h5oIBAp63ckHtE8GHlH4c8dZNBiAXn4Org==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.5.3.tgz",
+      "integrity": "sha512-piUMqoHNwDXChBfaaFIMzYgoxepfd8Ci1uXXNVEnuiRKz3FiIcNLmvXaBD7lKUwKcnGgVziH/CrndX6SldKQNQ==",
       "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.16.tgz",
-      "integrity": "sha512-/lmZeAN/qV5XbK2SEvi8e2RkIg8FQNYiSA8y2/Zb4gTUMKVO5JMLH0BSWMiIKMstKDPDSxMWgwJaQHF8UMyPmQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.5.3.tgz",
+      "integrity": "sha512-zV5utPYBUzYhBOomCByAjKAvfVBcOCJtnszx7Zlfz7SAv/cGm8D1QzPDCvv6jDhIlUtLj6KyL8JXeFr+f95Fjw==",
       "optional": true
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.4.16",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.16.tgz",
-      "integrity": "sha512-BPAfFfODWXtUu6SwaTTftDHvcbDyWBSI/oanUeRbQR5vVWkXoQ3cxLTsDluc3H74IqXS5z1Uyoe0vNo2hB1opA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.5.3.tgz",
+      "integrity": "sha512-QmUiXiPIV5gBADfDh8e2jKynEhyRC+dcKP/zF9y5KqDUErYzlhocLd68uYS4uIegP6AylYlmigHgcaktGEE9VQ==",
       "optional": true
     },
     "@swc/counter": {
@@ -13893,12 +13893,12 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.3.0.tgz",
-      "integrity": "sha512-5LjCSSno8E+IUCOX4hJiIb/upPIgpkaDEcaN/40gOcw26t/5UTLHFc4JdxKjOOvGTh0XdCu+fNr0fpOVNvcxMA==",
+      "version": "28.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.5.0.tgz",
+      "integrity": "sha512-6np6DGdmNq/eBbA7HOUNV8fkfL86PYwBfwyb8n23FXgJNTR8+ot3smRHjza9LGsBBZRypK3qyF79vMjohIL8eQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "^6.0.0"
+        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
       }
     },
     "eslint-plugin-jest-formatting": {
@@ -15555,9 +15555,9 @@
       }
     },
     "mongoose": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.3.2.tgz",
-      "integrity": "sha512-3JcpDjFI25cF/3xpu+4+9nM0lURQTNLcP86X83+LvuICdn453QQLmhSrUr2IPM/ffLiDE9KPl9slNb2s0hZPpg==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.3.4.tgz",
+      "integrity": "sha512-ckBaBzKgtWgCalW/LPkcBsR3wKCOYEJ9jLFPmYCYV7TLStpETY757ELx8/1stL11+6HxLLVffawBffXzd0Y7YA==",
       "requires": {
         "bson": "^6.5.0",
         "kareem": "2.6.3",
@@ -15565,7 +15565,7 @@
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.1"
+        "sift": "17.1.3"
       },
       "dependencies": {
         "@types/whatwg-url": {
@@ -16269,9 +16269,9 @@
       "dev": true
     },
     "sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
     },
     "signal-exit": {
       "version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -80,16 +80,16 @@
     "release": "npm run lint && npm run build && np"
   },
   "dependencies": {
-    "@swc/core": "1.4.16",
+    "@swc/core": "1.5.3",
     "@swc/register": "0.1.10",
     "chalk": "4.1.2",
     "commander": "12.0.0",
     "dotenv": "16.4.5",
     "inquirer": "8.2.6",
-    "mongoose": "8.3.2"
+    "mongoose": "8.3.4"
   },
   "devDependencies": {
-    "@shelf/jest-mongodb": "4.2.0",
+    "@shelf/jest-mongodb": "4.3.1",
     "@stylistic/eslint-plugin": "1.8.0",
     "@swc/cli": "0.3.12",
     "@swc/helpers": "0.5.11",
@@ -100,7 +100,7 @@
     "@typescript-eslint/eslint-plugin": "7.8.0",
     "@typescript-eslint/parser": "7.8.0",
     "eslint": "8.57.0",
-    "eslint-plugin-jest": "28.3.0",
+    "eslint-plugin-jest": "28.5.0",
     "eslint-plugin-jest-formatting": "3.1.0",
     "eslint-plugin-sonarjs": "0.25.1",
     "jest": "29.7.0",

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -51,9 +51,13 @@ export const getMigrator = async (options: IOptions): Promise<Migrator> => {
   config({ path: '.env' })
   config({ path: '.env.local', override: true })
 
-  if (options.mode) {
-    config({ path: `.env.${options.mode}`, override: true })
-    config({ path: `.env.${options.mode}.local`, override: true })
+  const mode = options.mode
+    ?? process.env['MIGRATE_MODE']
+    ?? process.env['migrateMode']
+
+  if (mode) {
+    config({ path: `.env.${mode}`, override: true })
+    config({ path: `.env.${mode}.local`, override: true })
   }
 
   const configPath = options.configPath

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -51,6 +51,11 @@ export const getMigrator = async (options: IOptions): Promise<Migrator> => {
   config({ path: '.env' })
   config({ path: '.env.local', override: true })
 
+  if (options.mode) {
+    config({ path: `.env.${options.mode}`, override: true })
+    config({ path: `.env.${options.mode}.local`, override: true })
+  }
+
   const configPath = options.configPath
     ?? process.env['MIGRATE_CONFIG_PATH']
     ?? process.env['migrateConfigPath']
@@ -135,6 +140,7 @@ export class Migrate {
       .option('-a, --autosync <boolean>', 'automatically sync new migrations without prompt')
       .option('-m, --migrations-path <path>', 'path to the migration files')
       .option('-t, --template-path <path>', 'template file to use when creating a migration')
+      .option('--mode <string>', 'environment mode to use .env.[mode] file')
       .hook('preAction', async () => {
         const opts = this.program.opts<IOptions>()
         this.migrator = await getMigrator(opts)

--- a/src/interfaces/IOptions.ts
+++ b/src/interfaces/IOptions.ts
@@ -8,6 +8,7 @@ interface IOptions {
   collection?: string
   autosync?: boolean
   configPath?: string
+  mode?: string
 }
 
 export default IOptions


### PR DESCRIPTION
Add mode to load specific env files `--mode development`
Mode can be any arbitrary string typical use cases: `development`, `test`, `staging`, `production`
```bash
.env                # loaded in all cases
.env.local          # loaded in all cases (used as override for local development)
.env.[mode]         # only loaded in specified mode
.env.[mode].local   # only loaded in specified mode (used as override for local development)
```
Overrides work top to bottom meaning last always wins
