### PR TITLE
Fixed getMigration filetype for built versions

### DIFF
--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -356,24 +356,24 @@ class Migrator {
    * @private
    * @async
    */
-private async getMigrations(): Promise<{
-  migrationsInDb: IMigration[]
-  migrationsInFs: IFileMigration[]
-}> {
-  const files = fs.readdirSync(this.migrationsPath)
-  const migrationsInDb = await this.migrationModel.find({}).exec()
+  private async getMigrations(): Promise<{
+    migrationsInDb: IMigration[]
+    migrationsInFs: IFileMigration[]
+  }> {
+    const files = fs.readdirSync(this.migrationsPath)
+    const migrationsInDb = await this.migrationModel.find({}).exec()
 
-  const fileExtensions = ['.ts', '.js'];
+    const fileExtensions = ['.ts', '.js']
 
-  const migrationsInFs = files
-    .filter((filename) => /^\d{13,}-/.test(filename) && fileExtensions.some(ext => filename.endsWith(ext)))
-    .map((filename) => {
-      const [time] = filename.split('-')
-      const timestamp = Number.parseInt(time ?? '')
-      const createdAt = new Date(timestamp)
-      const existsInDatabase = migrationsInDb.some((migration) => filename === migration.filename)
-      return { createdAt, filename, existsInDatabase }
-    })
+    const migrationsInFs = files
+      .filter((filename) => /^\d{13,}-/.test(filename) && fileExtensions.some((ext) => filename.endsWith(ext)))
+      .map((filename) => {
+        const [time] = filename.split('-')
+        const timestamp = Number.parseInt(time ?? '')
+        const createdAt = new Date(timestamp)
+        const existsInDatabase = migrationsInDb.some((migration) => filename === migration.filename)
+        return { createdAt, filename, existsInDatabase }
+      })
 
     return { migrationsInDb, migrationsInFs }
   }

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -356,21 +356,24 @@ class Migrator {
    * @private
    * @async
    */
-  private async getMigrations(): Promise<{
-    migrationsInDb: IMigration[]
-    migrationsInFs: IFileMigration[]
-  }> {
-    const files = fs.readdirSync(this.migrationsPath)
-    const migrationsInDb = await this.migrationModel.find({}).exec()
-    const migrationsInFs = files
-      .filter((filename) => /^\d{13,}-/.test(filename) && filename.endsWith('.ts'))
-      .map((filename) => {
-        const [time] = filename.split('-')
-        const timestamp = Number.parseInt(time ?? '')
-        const createdAt = new Date(timestamp)
-        const existsInDatabase = migrationsInDb.some((migration) => filename === migration.filename)
-        return { createdAt, filename, existsInDatabase }
-      })
+private async getMigrations(): Promise<{
+  migrationsInDb: IMigration[]
+  migrationsInFs: IFileMigration[]
+}> {
+  const files = fs.readdirSync(this.migrationsPath)
+  const migrationsInDb = await this.migrationModel.find({}).exec()
+
+  const fileExtensions = ['.ts', '.js'];
+
+  const migrationsInFs = files
+    .filter((filename) => /^\d{13,}-/.test(filename) && fileExtensions.some(ext => filename.endsWith(ext)))
+    .map((filename) => {
+      const [time] = filename.split('-')
+      const timestamp = Number.parseInt(time ?? '')
+      const createdAt = new Date(timestamp)
+      const existsInDatabase = migrationsInDb.some((migration) => filename === migration.filename)
+      return { createdAt, filename, existsInDatabase }
+    })
 
     return { migrationsInDb, migrationsInFs }
   }


### PR DESCRIPTION
### Pull Request Description:

**Subject: [PATCH] Fixed getMigrations filetype for built versions**

#### Summary:
This patch addresses an issue with the `getMigrations` function in `src/migrator.ts` where it was only filtering `.ts` files for migrations. The fix now allows the function to correctly handle both `.ts` and `.js` files, ensuring compatibility with built versions of the application that use JavaScript files instead of TypeScript.

#### Changes:
- Updated the `getMigrations` method to filter both `.ts` and `.js` files in the migrations folder.
- Introduced a conditional check to support both development and production environments, ensuring that migrations can be found whether the application is running with TypeScript or after being built to JavaScript.

#### Impact:
This change ensures that migrations can be correctly loaded regardless of whether the application is running in development mode (using TypeScript) or in production (using JavaScript after the build).

#### Related Issues:
- Fixes migration file loading issue for production builds.

#### Testing:
- Ensure that both `.ts` and `.js` migration files are correctly detected and processed when the application is built and deployed.

#### Additional Notes:
- The modification simplifies handling of migration files across environments and ensures smoother operation during the build and deployment phases.