### PR TITLE
Bump mongoose from 8.9.4 to 8.9.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "commander": "13.0.0",
         "dotenv": "16.4.7",
         "inquirer": "8.2.6",
-        "mongoose": "8.9.4"
+        "mongoose": "8.9.5"
       },
       "bin": {
         "migrate": "dist/cjs/bin.js"
@@ -6356,9 +6356,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.4.tgz",
-      "integrity": "sha512-DndoI01aV/q40P9DiYDXsYjhj8vZjmmuFwcC3Tro5wFznoE1z6Fe2JgMnbLR6ghglym5ziYizSfAJykp+UPZWg==",
+      "version": "8.9.5",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.5.tgz",
+      "integrity": "sha512-SPhOrgBm0nKV3b+IIHGqpUTOmgVL5Z3OO9AwkFEmvOZznXTvplbomstCnPOGAyungtRXE5pJTgKpKcZTdjeESg==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.1",
@@ -12282,9 +12282,9 @@
       }
     },
     "mongoose": {
-      "version": "8.9.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.4.tgz",
-      "integrity": "sha512-DndoI01aV/q40P9DiYDXsYjhj8vZjmmuFwcC3Tro5wFznoE1z6Fe2JgMnbLR6ghglym5ziYizSfAJykp+UPZWg==",
+      "version": "8.9.5",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.5.tgz",
+      "integrity": "sha512-SPhOrgBm0nKV3b+IIHGqpUTOmgVL5Z3OO9AwkFEmvOZznXTvplbomstCnPOGAyungtRXE5pJTgKpKcZTdjeESg==",
       "requires": {
         "bson": "^6.10.1",
         "kareem": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "commander": "13.0.0",
     "dotenv": "16.4.7",
     "inquirer": "8.2.6",
-    "mongoose": "8.9.4"
+    "mongoose": "8.9.5"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
This PR fixes https://github.com/advisories/GHSA-m7xq-9374-9rvx by bumping mongoose from 8.9.4 to 8.9.5

<img width="928" alt="image" src="https://github.com/user-attachments/assets/5ad041b1-3c2c-4ed1-8acb-81c731586490" />

