### PR TITLE
docs(readme): add users info

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@0.1.4

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A migration framework for Mongoose, built with TypeScript.
 
 [![npm](https://img.shields.io/npm/v/ts-migrate-mongoose)](https://www.npmjs.com/package/ts-migrate-mongoose)
 [![npm](https://img.shields.io/npm/dt/ts-migrate-mongoose)](https://www.npmjs.com/package/ts-migrate-mongoose)
+[![network dependents](https://dependents.info/ilovepixelart/ts-migrate-mongoose/badge)](https://dependents.info/ilovepixelart/ts-migrate-mongoose)
 [![GitHub](https://img.shields.io/github/license/ilovepixelart/ts-migrate-mongoose)](https://github.com/ilovepixelart/ts-migrate-mongoose/blob/main/LICENSE)
 \
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ilovepixelart_ts-migrate-mongoose&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ilovepixelart_ts-migrate-mongoose)


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a relevant auto-updated shields.io style network dependents badge (customizable) and the image in the `README.md` file to showcase its impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built some time ago and plan to maintain for long. It also creates an image preview of the users in the readme.

Here's how they would look for your repository:

<img width="693" alt="image" src="https://github.com/user-attachments/assets/2d29bf62-4bf2-4c9b-8944-da0166f82bac" />
<br /><br />

I haven't included the full image yet, but I can update the PR if you think it'll be good. [Here's](http://github.com/joshnuss/svelte-persisted-store) a project using it already.

Please feel free to close the PR if you don't want to have this!