### PR TITLE
Add OpenSSF Best Practices project 12477 + Fuzzing finding

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   },
   "cSpell.words": [
     "autosync",
+    "bestpractices",
     "biomejs",
     "dbaeumer",
     "Dsonar",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A migration framework for Mongoose, built with TypeScript.
 \
 [![Socket Badge](https://badge.socket.dev/npm/package/ts-migrate-mongoose)](https://socket.dev/npm/package/ts-migrate-mongoose)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/ilovepixelart/ts-migrate-mongoose/badge)](https://securityscorecards.dev/viewer/?uri=github.com/ilovepixelart/ts-migrate-mongoose)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12477/badge)](https://www.bestpractices.dev/en/projects/12477)
 
 ## Motivation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,3 +88,16 @@ chase:
   organizations in the last 30 commits. As a personal project this is
   structurally unattainable; the score will move organically if external
   contributors join.
+
+- **`Fuzzing`** — `ts-migrate-mongoose` has no parser or untrusted
+  input surface. Configuration comes from trusted files (`migrate.json`,
+  `migrate.ts`, `.env`) and CLI flags; migration bodies are executed as
+  trusted code authored by the project's own maintainers. A continuous
+  fuzzer (CIFuzz, OSS-Fuzz) would have no meaningful input corpus to
+  mutate.
+
+- **`CII-Best-Practices`** — tracked at
+  [bestpractices.dev/projects/12477](https://www.bestpractices.dev/en/projects/12477).
+  The project targets the "passing" tier; "silver" and "gold" require
+  multiple reviewers and documented security-review processes that are
+  out of reach for a single-maintainer project.


### PR DESCRIPTION
## Summary

- Register the project under [bestpractices.dev/projects/12477](https://www.bestpractices.dev/en/projects/12477) and link it from SECURITY.md's `CII-Best-Practices` accepted-findings entry.
- Add the OpenSSF Best Practices badge to README (row 2, next to Socket and Scorecard).
- Document `Fuzzing` as an accepted Scorecard finding — `ts-migrate-mongoose` has no parser or untrusted input surface; config comes from trusted files (`migrate.json` / `migrate.ts` / `.env`) and migration bodies are maintainer-authored code. A continuous fuzzer would have no meaningful corpus.
- `.vscode/settings.json`: add `bestpractices` to the cSpell dictionary.

Closes the Scorecard `CII-Best-Practices` + `Fuzzing` findings by documenting accepted rationale and registering the project.

## Test plan
- [x] `npm run type:check`
- [x] `npm run biome`
- [ ] OpenSSF Best Practices badge renders in README
- [ ] Scorecard next weekly run reflects CII-Best-Practices detection