### PR TITLE
Add fast-check property tests for env.parse + feature_request rewrite

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,31 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for ts-migrate-mongoose
 title: ''
-labels: ''
+labels: enhancement
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is your feature request related to a problem?**
+A clear and concise description of the problem. Ex. "I need to run
+migrations against a read-replica before promoting it, but …"
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+What you want to happen — new CLI flag, new config option, new
+`Migrator` method, NestJS integration change, etc.
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+Other approaches, workarounds, or existing options you've tried.
+
+**Mode**
+Which surface would this touch?
+
+- [ ] CLI (`npx migrate …`)
+- [ ] Programmatic (`Migrator.connect(...)`)
+- [ ] NestJS (`MigrationModule`)
+- [ ] Config file (`migrate.json` / `migrate.ts` / `.env`)
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Anything else — related issues, upstream mongoose features, links to
+similar implementations in other migration tools, etc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,13 +89,6 @@ chase:
   structurally unattainable; the score will move organically if external
   contributors join.
 
-- **`Fuzzing`** — `ts-migrate-mongoose` has no parser or untrusted
-  input surface. Configuration comes from trusted files (`migrate.json`,
-  `migrate.ts`, `.env`) and CLI flags; migration bodies are executed as
-  trusted code authored by the project's own maintainers. A continuous
-  fuzzer (CIFuzz, OSS-Fuzz) would have no meaningful input corpus to
-  mutate.
-
 - **`CII-Best-Practices`** — tracked at
   [bestpractices.dev/projects/12477](https://www.bestpractices.dev/en/projects/12477).
   The project targets the "passing" tier; "silver" and "gold" require

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/common": "11.1.18",
         "@types/node": "25.6.0",
         "@vitest/coverage-v8": "4.1.4",
+        "fast-check": "4.6.0",
         "mongodb-memory-server": "11.0.1",
         "np": "11.0.3",
         "open-cli": "9.0.0",
@@ -3079,6 +3080,29 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/fast-fifo": {
@@ -6593,6 +6617,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@nestjs/common": "11.1.18",
     "@types/node": "25.6.0",
     "@vitest/coverage-v8": "4.1.4",
+    "fast-check": "4.6.0",
     "mongodb-memory-server": "11.0.1",
     "np": "11.0.3",
     "open-cli": "9.0.0",

--- a/tests/env.property.test.ts
+++ b/tests/env.property.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+
+import fc from 'fast-check'
+import { parse } from '../src/env'
+
+// Keys match the /[\w.-]+/ character class the parser accepts.
+const keyArb = fc.stringMatching(/^[A-Za-z_][\w.-]{0,15}$/)
+
+// Safe values: no quotes, no backslashes, no line breaks, no '#' (would be
+// treated as a comment). Values are trimmed to match parse() which strips
+// leading and trailing whitespace from unquoted values.
+const safeValueArb = fc.stringMatching(/^[^\r\n'"`\\#]{0,40}$/).map((s) => s.trim())
+
+const envObjectArb = fc.dictionary(keyArb, safeValueArb, { maxKeys: 8 })
+
+const serialize = (obj: Record<string, string>): string =>
+  Object.entries(obj)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('\n')
+
+describe('env.parse — properties', () => {
+  it('never throws on any string input', () => {
+    fc.assert(
+      fc.property(fc.string(), (src) => {
+        expect(() => parse(src)).not.toThrow()
+      }),
+    )
+  })
+
+  it('returns a plain object on any string input', () => {
+    fc.assert(
+      fc.property(fc.string(), (src) => {
+        const result = parse(src)
+        expect(typeof result).toBe('object')
+        expect(result).not.toBeNull()
+        expect(Array.isArray(result)).toBe(false)
+      }),
+    )
+  })
+
+  it('every parsed key matches the /[\\w.-]+/ character class', () => {
+    fc.assert(
+      fc.property(fc.string(), (src) => {
+        const result = parse(src)
+        for (const key of Object.keys(result)) {
+          expect(key).toMatch(/^[\w.-]+$/)
+        }
+      }),
+    )
+  })
+
+  it('every parsed value is a string', () => {
+    fc.assert(
+      fc.property(fc.string(), (src) => {
+        const result = parse(src)
+        for (const value of Object.values(result)) {
+          expect(typeof value).toBe('string')
+        }
+      }),
+    )
+  })
+
+  it('round-trips simple KEY=value serialization', () => {
+    fc.assert(
+      fc.property(envObjectArb, (obj) => {
+        expect(parse(serialize(obj))).toEqual(obj)
+      }),
+    )
+  })
+
+  it('is idempotent: parse(serialize(parse(serialize(x)))) === parse(serialize(x))', () => {
+    fc.assert(
+      fc.property(envObjectArb, (obj) => {
+        const once = parse(serialize(obj))
+        const twice = parse(serialize(once))
+        expect(twice).toEqual(once)
+      }),
+    )
+  })
+
+  it('comment-only lines are ignored', () => {
+    fc.assert(
+      fc.property(fc.array(fc.stringMatching(/^#[^\r\n]{0,40}$/), { maxLength: 5 }), (comments) => {
+        expect(parse(comments.join('\n'))).toEqual({})
+      }),
+    )
+  })
+
+  it('blank lines are ignored', () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 20 }), (n) => {
+        expect(parse('\n'.repeat(n))).toEqual({})
+      }),
+    )
+  })
+
+  it('trailing # comment is stripped from value', () => {
+    fc.assert(
+      fc.property(keyArb, safeValueArb, fc.stringMatching(/^[^\r\n]{0,20}$/), (key, value, comment) => {
+        const src = `${key}=${value} # ${comment}`
+        const result = parse(src)
+        expect(result[key]).toBe(value)
+      }),
+    )
+  })
+
+  it('double-quoted values have \\n and \\r escape sequences expanded', () => {
+    fc.assert(
+      fc.property(keyArb, fc.stringMatching(/^[^\r\n'"`\\#]{0,20}$/), (key, inner) => {
+        const src = `${key}="${inner}\\n${inner}"`
+        expect(parse(src)[key]).toBe(`${inner}\n${inner}`)
+      }),
+    )
+  })
+
+  it('single-quoted values do NOT expand escape sequences', () => {
+    fc.assert(
+      fc.property(keyArb, fc.stringMatching(/^[^\r\n'"`\\#]{0,20}$/), (key, inner) => {
+        const src = `${key}='${inner}\\n${inner}'`
+        expect(parse(src)[key]).toBe(`${inner}\\n${inner}`)
+      }),
+    )
+  })
+
+  it('normalizes CRLF and CR to LF before parsing', () => {
+    fc.assert(
+      fc.property(envObjectArb, (obj) => {
+        const lf = serialize(obj)
+        const crlf = lf.replaceAll('\n', '\r\n')
+        const cr = lf.replaceAll('\n', '\r')
+        expect(parse(crlf)).toEqual(parse(lf))
+        expect(parse(cr)).toEqual(parse(lf))
+      }),
+    )
+  })
+
+  it('export prefix is stripped: `export KEY=value` parses to {KEY: "value"}', () => {
+    fc.assert(
+      fc.property(keyArb, safeValueArb, (key, value) => {
+        expect(parse(`export ${key}=${value}`)).toEqual({ [key]: value })
+      }),
+    )
+  })
+
+  it('does not mutate its input string (strings are immutable; assert the returned object has no aliasing of the input)', () => {
+    fc.assert(
+      fc.property(fc.string(), (src) => {
+        const before = src
+        parse(src)
+        expect(src).toBe(before)
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Two small follow-ups after PR #475 / #476:

### 1. Earn Scorecard Fuzzing check via `fast-check`

Scorecard credits `fast-check` as a JS/TS property-based testing library (alongside OSS-Fuzz and ClusterFuzzLite). Earning the check legitimately is cheaper than documenting it as an accepted finding, and gives us real test coverage as a bonus.

- Pin `fast-check@4.6.0` as a devDep
- New `tests/env.property.test.ts` covering `src/env.ts#parse()` — the most structured-input surface in the repo. Properties verify:
  - **Robustness**: `parse()` never throws on any string input, always returns a plain object with string values, every parsed key matches the `/[\w.-]+/` character class the parser accepts
  - **Round-trip**: `parse(serialize(obj)) === obj` for any safe `Record<string, string>`
  - **Idempotence**: `parse(serialize(parse(serialize(x)))) === parse(serialize(x))`
  - **Comment / blank line handling**: comment-only lines and blank lines parse to `{}`; trailing `# comment` is stripped from unquoted values
  - **Quote semantics**: double-quoted values expand `\n` and `\r` escape sequences; single-quoted values do not
  - **Line-ending normalization**: CRLF and CR inputs parse identically to their LF equivalents
  - **`export KEY=value`** prefix is stripped
  - **Input immutability**: `parse()` does not mutate the source string
- Drop the `Fuzzing` entry from `SECURITY.md`'s accepted-findings section — we are earning the check now, not accepting it

Expected Scorecard impact: **Fuzzing 0/10 → 10/10** on next weekly scan.

### 2. Rewrite feature_request issue template

Match the `bug_report.md` rewrite from PR #475: default `labels: enhancement`, project-specific framing (CLI / Programmatic / NestJS / config file modes), drop the generic GitHub starter boilerplate.

## Test plan
- [x] `npm run type:check`
- [x] `npm run type:check:tests`
- [x] `npm run biome`
- [x] `npm test` — 179/179 passing (165 existing + 14 new property tests)
- [ ] Scorecard next weekly run credits Fuzzing