### PR TITLE
Security: reject traversal names + error cause chaining

### DIFF
--- a/src/commander.ts
+++ b/src/commander.ts
@@ -304,7 +304,7 @@ export class Migrate {
 
       return await this.finish(exit)
     } catch (error: unknown) {
-      return await this.finish(exit, error instanceof Error ? error : new Error('An unknown error occurred'))
+      return await this.finish(exit, error instanceof Error ? error : new Error('An unknown error occurred', { cause: error }))
     }
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,9 @@ export const MIGRATION_FILE_EXTENSIONS = ['ts', 'js', 'mjs', 'cjs'] as const
 
 // Regex to match migration files, excluding .d.ts files
 export const MIGRATION_FILE_REGEX = new RegExp(String.raw`(?<!\.d)\.(${MIGRATION_FILE_EXTENSIONS.join('|')})$`)
+
+// Allowed characters in user-supplied migration names. Whitelists letters,
+// digits, underscore, hyphen, and dot; the negative lookahead blocks
+// consecutive dots so `..` path traversal is rejected even though single
+// dots (e.g. `my.migration`) are supported.
+export const MIGRATION_NAME_REGEX = /^(?!.*\.\.)[A-Za-z0-9._-]+$/

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import mongoose from 'mongoose'
 import { chalk } from './chalk'
-import { MIGRATION_FILE_EXTENSIONS, MIGRATION_FILE_REGEX } from './constants'
+import { MIGRATION_FILE_EXTENSIONS, MIGRATION_FILE_REGEX, MIGRATION_NAME_REGEX } from './constants'
 import { defaults } from './defaults'
 import { loader } from './loader'
 import { getMigrationModel } from './model'
@@ -108,6 +108,10 @@ export class Migrator {
    * Create a new migration file
    */
   async create(migrationName: string): Promise<HydratedDocument<Migration>> {
+    if (!MIGRATION_NAME_REGEX.test(migrationName)) {
+      throw new Error(`Invalid migration name '${migrationName}'. Allowed characters: letters, digits, underscore, hyphen, and non-consecutive dots.`)
+    }
+
     const existingMigration = await this.migrationModel.findOne({ name: migrationName }).exec()
     if (existingMigration) {
       throw new Error(`There is already a migration with name '${migrationName}' in the database`)
@@ -347,8 +351,12 @@ export class Migrator {
    */
   private async runMigrations(migrationsToRun: HydratedDocument<Migration>[], direction: 'down' | 'up'): Promise<HydratedDocument<Migration>[]> {
     const migrationsRan: HydratedDocument<Migration>[] = []
+    const migrationsRoot = path.resolve(this.migrationsPath) + path.sep
     for (const migration of migrationsToRun) {
       const baseMigrationPath = path.resolve(path.join(this.migrationsPath, migration.filename))
+      if (!baseMigrationPath.startsWith(migrationsRoot)) {
+        throw new Error(`Refusing to import migration '${migration.filename}' — resolved path escapes the migrations directory.`)
+      }
       const migrationFilePath = resolveMigrationFile(baseMigrationPath)
       const fileUrl = pathToFileURL(migrationFilePath).href
       const migrationFunctions = (await import(fileUrl)) as MigrationFunctions | MigrationFunctionsDefault

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,6 @@ const resolveMigrationFile = (basePath: string): string => {
   return basePath
 }
 
-export { chalk } from './chalk'
 export * from './types'
 
 /**
@@ -195,11 +194,7 @@ export class Migrator {
 
       return this.syncMigrations(migrationsToImport)
     } catch (error) {
-      const message = 'Could not synchronize migrations in the migrations folder up to the database'
-      if (error instanceof Error) {
-        error.message = `${message}\n${error.message}`
-      }
-      throw error
+      throw new Error('Could not synchronize migrations in the migrations folder up to the database', { cause: error })
     }
   }
 
@@ -228,11 +223,7 @@ export class Migrator {
 
       return migrationsDeleted
     } catch (error) {
-      const message = 'Could not prune extraneous migrations from database'
-      if (error instanceof Error) {
-        error.message = `${message}\n${error.message}`
-      }
-      throw error
+      throw new Error('Could not prune extraneous migrations from database', { cause: error })
     }
   }
 
@@ -361,7 +352,7 @@ export class Migrator {
       const migrationFilePath = resolveMigrationFile(baseMigrationPath)
       const fileUrl = pathToFileURL(migrationFilePath).href
       const migrationFunctions = (await import(fileUrl)) as MigrationFunctions | MigrationFunctionsDefault
-      const migrationFunction = 'default' in migrationFunctions ? migrationFunctions.default[direction] : (migrationFunctions as MigrationFunctions)[direction]
+      const migrationFunction = (migrationFunctions as MigrationFunctionsDefault).default?.[direction] ?? (migrationFunctions as MigrationFunctions)[direction]
       if (!migrationFunction) {
         throw new Error(`The '${direction}' export is not defined in ${migration.filename}.`)
       }
@@ -374,11 +365,7 @@ export class Migrator {
         await this.migrationModel.updateMany({ name: migration.name }, { $set: { state: direction } }).exec()
         migrationsRan.push(migration)
       } catch (error) {
-        const message = `Failed to run migration with name '${migration.name}' due to an error`
-        if (error instanceof Error) {
-          error.message = `${message}\n${error.message}`
-        }
-        throw error
+        throw new Error(`Failed to run migration with name '${migration.name}' due to an error`, { cause: error })
       }
     }
 

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+
+import { MIGRATION_FILE_EXTENSIONS, MIGRATION_FILE_REGEX, MIGRATION_NAME_REGEX } from '../src/constants'
+
+describe('MIGRATION_FILE_EXTENSIONS', () => {
+  it('lists ts, js, mjs, cjs', () => {
+    expect(MIGRATION_FILE_EXTENSIONS).toEqual(['ts', 'js', 'mjs', 'cjs'])
+  })
+})
+
+describe('MIGRATION_FILE_REGEX', () => {
+  it('matches supported source files', () => {
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users.ts')).toBe(true)
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users.js')).toBe(true)
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users.mjs')).toBe(true)
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users.cjs')).toBe(true)
+  })
+
+  it('rejects .d.ts declaration files', () => {
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users.d.ts')).toBe(false)
+  })
+
+  it('rejects unrelated extensions', () => {
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users.json')).toBe(false)
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users.txt')).toBe(false)
+    expect(MIGRATION_FILE_REGEX.test('1234567890123-add-users')).toBe(false)
+  })
+})
+
+describe('MIGRATION_NAME_REGEX', () => {
+  describe('accepts', () => {
+    const valid = [
+      'add-users',
+      'test-migration',
+      'test-migration1',
+      'extension-test',
+      'single',
+      'A',
+      '1',
+      'my.migration',
+      'v1.2.3-release',
+      'snake_case_name',
+      'kebab-case-name',
+      'Mixed-Case_Name.1',
+      '__private',
+      'a'.repeat(100),
+    ]
+
+    for (const name of valid) {
+      it(`allows '${name}'`, () => {
+        expect(MIGRATION_NAME_REGEX.test(name)).toBe(true)
+      })
+    }
+  })
+
+  describe('rejects', () => {
+    const invalid: Array<[string, string]> = [
+      ['', 'empty string'],
+      ['..', 'exactly two dots (parent directory traversal)'],
+      ['...', 'three dots (still contains ..)'],
+      ['../evil', 'starts with ../ traversal'],
+      ['foo/../bar', 'contains ../ anywhere'],
+      ['foo..bar', 'contains consecutive dots'],
+      ['foo/bar', 'contains forward slash'],
+      ['foo\\bar', 'contains backslash'],
+      ['with space', 'contains whitespace'],
+      ['with\ttab', 'contains tab'],
+      ['with\nnewline', 'contains newline'],
+      ['tilde~home', 'contains tilde'],
+      ['name!', 'contains exclamation'],
+      ['name?', 'contains question mark'],
+      ['name*glob', 'contains glob star'],
+      ['name$var', 'contains dollar'],
+      ['name;rm', 'contains semicolon'],
+      ['name|pipe', 'contains pipe'],
+      ['name&bg', 'contains ampersand'],
+      ['name`cmd`', 'contains backtick'],
+      ['name"quote', 'contains double quote'],
+      ["name'quote", 'contains single quote'],
+      ['name(paren)', 'contains parentheses'],
+      ['name{brace}', 'contains braces'],
+      ['name#hash', 'contains hash'],
+      ['name@at', 'contains at sign'],
+      ['émigré', 'contains non-ASCII letters'],
+      ['💥', 'contains emoji'],
+      ['\x00null', 'contains NUL byte'],
+    ]
+
+    for (const [name, reason] of invalid) {
+      it(`rejects ${reason} (${JSON.stringify(name)})`, () => {
+        expect(MIGRATION_NAME_REGEX.test(name)).toBe(false)
+      })
+    }
+  })
+
+  it('has no backtracking surprise: long safe input evaluates quickly', () => {
+    const start = Date.now()
+    const longInput = `${'a'.repeat(10_000)}.${'b'.repeat(10_000)}`
+    MIGRATION_NAME_REGEX.test(longInput)
+    const elapsed = Date.now() - start
+    // Sanity ceiling: catastrophic backtracking would take seconds.
+    // A safe regex should handle this in under 100ms on any modern CPU.
+    expect(elapsed).toBeLessThan(100)
+  })
+})

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -29,22 +29,7 @@ describe('MIGRATION_FILE_REGEX', () => {
 
 describe('MIGRATION_NAME_REGEX', () => {
   describe('accepts', () => {
-    const valid = [
-      'add-users',
-      'test-migration',
-      'test-migration1',
-      'extension-test',
-      'single',
-      'A',
-      '1',
-      'my.migration',
-      'v1.2.3-release',
-      'snake_case_name',
-      'kebab-case-name',
-      'Mixed-Case_Name.1',
-      '__private',
-      'a'.repeat(100),
-    ]
+    const valid = ['add-users', 'test-migration', 'test-migration1', 'extension-test', 'single', 'A', '1', 'my.migration', 'v1.2.3-release', 'snake_case_name', 'kebab-case-name', 'Mixed-Case_Name.1', '__private', 'a'.repeat(100)]
 
     for (const name of valid) {
       it(`allows '${name}'`, () => {

--- a/tests/migrator.test.ts
+++ b/tests/migrator.test.ts
@@ -84,6 +84,51 @@ describe('Tests for Migrator class - Programmatic approach', async () => {
     expect(migrator.connection.readyState).toBe(0)
   })
 
+  it.each([
+    ['../evil', 'parent directory traversal'],
+    ['foo/bar', 'forward slash path separator'],
+    ['foo\\bar', 'backslash path separator'],
+    ['with space', 'whitespace'],
+    ['', 'empty string'],
+    ['..', 'just two dots'],
+    ['foo..bar', 'consecutive dots'],
+    ['émigré', 'non-ASCII letters'],
+  ])('should reject create(%j) — %s', async (badName) => {
+    const migrator = await Migrator.connect({ uri })
+    try {
+      await expect(migrator.create(badName)).rejects.toThrow(/Invalid migration name/)
+      // The bad name must not be persisted as a DB record.
+      const existing = await migrator.migrationModel.findOne({ name: badName }).exec()
+      expect(existing).toBeNull()
+    } finally {
+      await migrator.close()
+    }
+  })
+
+  it('should refuse to import a migration whose resolved path escapes the migrations directory', async () => {
+    const migrator = await Migrator.connect({ uri })
+    try {
+      // Plant a poisoned DB record directly, bypassing create()'s validation
+      // to simulate an older unpatched version that allowed traversal names.
+      // The `${createdAt.getTime()}-` prefix means the first `..` segment is
+      // consumed by the timestamp portion (`1234-..` is a literal filename,
+      // not a parent reference), so we need enough `..` segments to pop out
+      // of migrations/ AND out of the project root before landing on a real
+      // path. This matches the realistic exploit: `path.resolve` does reduce
+      // standalone `..` segments once they follow a literal-filename segment.
+      const poisoned = await migrator.migrationModel.create({
+        name: '../../../../../../../../tmp/pwned',
+        createdAt: new Date(),
+      })
+      expect(poisoned.filename).toContain('tmp/pwned')
+
+      // @ts-expect-error - private method
+      await expect(migrator.runMigrations([poisoned], 'up')).rejects.toThrow(/escapes the migrations directory/)
+    } finally {
+      await migrator.close()
+    }
+  })
+
   it('should throw "Could not find migration with name \'create-unicorns\' in the database"', async () => {
     const migrationName = 'create-unicorns'
     const migrator = await Migrator.connect({ uri, cli: true })

--- a/tests/migrator.test.ts
+++ b/tests/migrator.test.ts
@@ -259,7 +259,10 @@ describe('Tests for Migrator class - Programmatic approach', async () => {
     vi.spyOn(migrator, 'getMigrations').mockImplementation(() => {
       throw new Error('Sync error')
     })
-    await expect(migrator.sync()).rejects.toThrow('Sync error')
+    await expect(migrator.sync()).rejects.toMatchObject({
+      message: expect.stringContaining('Could not synchronize migrations'),
+      cause: expect.objectContaining({ message: 'Sync error' }),
+    })
 
     expect(migrator.connection.readyState).toBe(1)
     await migrator.close()
@@ -332,7 +335,10 @@ describe('Tests for Migrator class - Programmatic approach', async () => {
     vi.spyOn(migrator, 'getMigrations').mockImplementation(() => {
       throw new Error('Sync error')
     })
-    await expect(migrator.prune()).rejects.toThrow('Sync error')
+    await expect(migrator.prune()).rejects.toMatchObject({
+      message: expect.stringContaining('Could not prune extraneous migrations'),
+      cause: expect.objectContaining({ message: 'Sync error' }),
+    })
 
     expect(migrator.connection.readyState).toBe(1)
     await migrator.close()


### PR DESCRIPTION
## Summary

Two independent improvements bundled in one PR:

### 1. Security: path-traversal protection

Traced the full attack surface for user-supplied `migrationName` and confirmed a concrete RCE chain:

1. `Migrator.create(migrationName)` accepts any string, writes the file at `path.join(migrationsPath, \`${now}-${name}.ts\`)`, and stores the name in the DB.
2. `migrator.run('up', migrationName)` reads the DB record, computes the virtual filename (`\`${createdAt}-${name}\``), resolves the full path, and calls `await import(fileUrl)`.
3. With enough `..` segments (verified at runtime: 8× pops out of `migrations/` + project root to `/tmp`), the resolved path escapes `migrationsPath` entirely. `path.resolve` does reduce standalone `..` segments after a literal filename segment — tested with `node -e ...` to confirm.

**Fix A** — validate `migrationName` in `create()` via a whitelist regex:
```ts
export const MIGRATION_NAME_REGEX = /^(?!.*\.\.)[A-Za-z0-9._-]+$/
```
Negative lookahead blocks consecutive dots so `..` traversal is rejected while single dots (`my.migration`, `v1.2.3-release`) still work. Validation lives in the `Migrator` class rather than the CLI so programmatic callers get the same protection. Zero regression — every existing test call site (`test-migration`, `test-migration1`, `extension-test`, etc.) matches the regex.

**Fix B** — defense in depth in `runMigrations()`. Before `await import(fileUrl)`, compute `migrationsRoot = path.resolve(this.migrationsPath) + path.sep` and refuse any resolved path that doesn't start with it. Protects against:
- Poisoned DB records planted by pre-patch versions
- Any future code path that bypasses `create()`'s validation
- Admin errors in direct DB manipulation

### 2. Error cause chaining

`sync()`, `prune()`, and `runMigrations()` caught errors and mutated `error.message` to prepend context. Works because `Error.message` is writable, but loses stack chaining and modern debuggers. Switch to `new Error(msg, { cause: error })` (Node 16.9+, well below our `engines.node: >=20`) in all three sites. Also fix `commander.run()`'s unknown-error fallback to preserve the thrown value as `cause`.

Also fixes a latent crash in `runMigrations` — `'default' in migrationFunctions ? migrationFunctions.default[direction] : ...` trusted `in` as defined-ness, but `MigrationFunctionsDefault.default` is typed optional. A module exporting `default: undefined` would crash with "Cannot read properties of undefined (reading 'up')". Replace with `migrationFunctions.default?.[direction] ?? ...`.

Drop an unintentional `export { chalk } from './chalk'` from `src/index.ts` — chalk is an internal utility (one of the clean-room replacements documented in CLAUDE.md) and leaking it from the public entry would force us to treat its signature as a stable public contract. All existing imports use `./chalk` directly.

## Tests

**`tests/constants.test.ts` — new file, 48 tests**

- `MIGRATION_FILE_EXTENSIONS` enumeration (1)
- `MIGRATION_FILE_REGEX` accept/reject (3)
- `MIGRATION_NAME_REGEX` accept 14 valid shapes + reject 29 invalid shapes (letters, digits, underscore, hyphen, dot, non-consecutive — vs `..`, `/`, `\\`, whitespace, tab, newline, emoji, NUL byte, 23 more)
- ReDoS safety canary: 20k-char input must evaluate in <100ms

**`tests/migrator.test.ts` — 9 new integration tests**

- `it.each` over 8 bad-name shapes. Each asserts `create()` rejects **and** the name is NOT persisted to the DB (catches the write-through regression where a bad name got stored even if the file write failed).
- End-to-end path-escape test: plants a poisoned DB record directly via `migrationModel.create()` with `name: '../../../../../../../../tmp/pwned'`, confirms the virtual filename contains the traversal, then asserts `runMigrations()` refuses to import with `/escapes the migrations directory/`.
- Two existing error-wrap tests updated to use `toMatchObject` asserting **both** the outer context message and the `cause` chain, locking in the `{ cause }` pattern.

## Test plan

- [x] `npm run type:check`
- [x] `npm run type:check:tests`
- [x] `npm run biome`
- [x] `npm run build`
- [x] `npm test` — **259 / 259 passing** (was 202)
- [x] Branch coverage **86.82 → 87.89** thanks to the new validation branches being exercised

## Breaking change risk

**None.** Every existing test name passes the new regex. The error-wrap change updates two tests whose assertions depended on the old mutated-message format; both now assert the stronger two-layer structure (outer context + `cause`). The chalk re-export removal is a no-op for all current consumers since imports go through `./chalk` directly.