### PR TITLE
Attach Sigstore bundle to Release as third provenance channel

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Build, attest, and pack
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write             # upload the attestation bundle to the triggering release
       id-token: write             # OIDC token for Sigstore keyless signing
       attestations: write         # persist the build provenance attestation
       artifact-metadata: write    # create the artifact storage record that backs the attestation
@@ -63,9 +63,29 @@ jobs:
         # actions/attest is the canonical action per the docs; actions/attest-build-provenance
         # is now a thin wrapper around it. Default predicate type is SLSA v1 build provenance,
         # which is what we want for npm tarballs — no extra inputs needed.
+        id: attest
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: ${{ steps.pack.outputs.tarball-name }}
+
+      - name: Attach attestation bundle to release
+        # SLSA v1.0 recommends publishing provenance in more than one channel.
+        # actions/attest already uploaded the bundle to GitHub's native attestation
+        # store and npm will ship an npm-registry provenance attestation via
+        # publishConfig.provenance: true. This third channel puts the same Sigstore
+        # bundle on the GitHub Release as a sidecar asset (<tarball>.sigstore.json)
+        # so consumers who rely on the classic "signed release assets" pattern —
+        # including OpenSSF Scorecard's Signed-Releases check — can find it too.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+          TARBALL: ${{ steps.pack.outputs.tarball-name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          asset="${TARBALL}.sigstore.json"
+          cp "$BUNDLE_PATH" "$asset"
+          gh release upload "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY" --clobber
 
       - name: Upload tarball artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -120,14 +120,17 @@ step in that attack chain.
 
 ### Release verifiability
 
-SLSA v1.0's
-[distributing provenance guidance](https://slsa.dev/spec/v1.0/distributing-provenance)
+[SLSA v1.2's distributing-provenance guidance](https://slsa.dev/spec/v1.2/distributing-provenance)
 states that producers **MUST** publish attestations in at least one
 place and **SHOULD** publish in more than one — the rationale being
 that independent channels give consumers more than one way to
-verify and remove any single point of failure. This project
-publishes the same SLSA v1 build provenance in **three** channels on
-every release:
+verify and remove any single point of failure. (The same normative
+requirements appeared in v1.0; v1.2's notable addition is the
+[Source Track](https://slsa.dev/spec/v1.2/whats-new), which applies
+to source code development processes and is orthogonal to the
+build-provenance pipeline described here.) This project publishes
+the same SLSA v1 build provenance in **three** channels on every
+release:
 
 1. **npm registry provenance** — emitted automatically by
    `npm publish` because `publishConfig.provenance: true` is set in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -120,31 +120,53 @@ step in that attack chain.
 
 ### Release verifiability
 
-**Status:** the hardened pipeline described above was introduced in
-the 5.2.x maintenance series but no release has yet been cut under
-it — `5.2.0` predates the new `publish.yaml`. Starting with **the
-next release**, every published tarball will ship with both an npm
-provenance attestation and a SLSA `.intoto.jsonl` on the GitHub
-Release. Consumers auditing a specific version can confirm which
-pipeline it was built under by looking for the attestation; its
-absence means the release pre-dates the hardened pipeline.
+SLSA v1.0's
+[distributing provenance guidance](https://slsa.dev/spec/v1.0/distributing-provenance)
+states that producers **MUST** publish attestations in at least one
+place and **SHOULD** publish in more than one — the rationale being
+that independent channels give consumers more than one way to
+verify and remove any single point of failure. This project
+publishes the same SLSA v1 build provenance in **three** channels on
+every release:
 
-Once the first post-hardening release is published:
+1. **npm registry provenance** — emitted automatically by
+   `npm publish` because `publishConfig.provenance: true` is set in
+   `package.json`. Verifiable with
+   [`npm audit signatures`](https://docs.npmjs.com/generating-provenance-statements).
+   The sonar job of `pr-check.yaml` runs that command on every PR so
+   we notice if any of our dev-dependencies lose their provenance
+   upstream.
+2. **GitHub native attestation store** — produced by
+   [`actions/attest@v4`](https://github.com/actions/attest) in the
+   `build` job. Stored at
+   [github.com/ilovepixelart/ts-migrate-mongoose/attestations](https://github.com/ilovepixelart/ts-migrate-mongoose/attestations)
+   and verifiable through `gh attestation verify` — no extra tooling
+   install required by consumers who already have the `gh` CLI.
+3. **GitHub Release asset** — the same Sigstore bundle is copied to
+   a sidecar file named `<tarball>.sigstore.json` and attached to
+   the GitHub Release via `gh release upload` in a follow-up step of
+   the same job. This is the "classic" distribution channel used by
+   tools that inspect release assets directly (including
+   OpenSSF Scorecard's `Signed-Releases` check).
 
-- Every tarball will ship with an
-  [npm provenance attestation](https://docs.npmjs.com/generating-provenance-statements)
-  linking it to the exact GitHub Actions run that built it. Consumers
-  can verify with `npm audit signatures`. The sonar job of
-  `pr-check.yaml` already runs this step on every PR so we notice if
-  any of our dev-dependencies lose their provenance upstream.
-- Every build additionally produces a **GitHub-native artifact
-  attestation** via `actions/attest-build-provenance`. The attestation
-  lives in GitHub's attestation store (not in Release assets) and is
-  verifiable through the `gh` CLI — no extra tooling install required
-  by consumers who already have `gh`. This runs independently of the
-  npm publish flow so users pinning to a git ref, downloading the
-  tarball from the Release page directly, or auditing the provenance
-  chain without trusting the npm registry can still verify the build.
+**Status:** the hardened pipeline was introduced in the 5.2.x
+maintenance series but the three-channel attestation story (above)
+is complete only **from `5.3.1` onward**:
+
+- `5.2.0` predates the new `publish.yaml` entirely — no provenance
+  in any channel.
+- `5.3.0` was released under `actions/attest@v4` but before the
+  release-asset sidecar step was added, so it has channels 1 and 2
+  (npm registry + GitHub attestation store) but no
+  `.sigstore.json` asset on the release.
+- `5.3.1+` has all three channels.
+
+Consumers auditing a specific version can confirm which pipeline
+it was built under by looking at the release: a `.sigstore.json`
+asset means `5.3.1+` shape; presence in
+[the attestation store](https://github.com/ilovepixelart/ts-migrate-mongoose/attestations)
+without the sidecar asset means `5.3.0`; absence from both means
+`5.2.0` or earlier.
 
 ### Dev-environment isolation
 
@@ -215,6 +237,28 @@ predicate type (which is what `actions/attest@v4` emits), queries
 GitHub's public Sigstore instance, and requires no additional tooling
 install beyond `gh` itself. For public repositories the attestation
 store is accessible without authentication.
+
+**Offline check (classic release-asset path):**
+
+For `5.3.1+` releases, the same Sigstore bundle is also attached to
+the GitHub Release as a sidecar file named
+`ts-migrate-mongoose-X.Y.Z.tgz.sigstore.json`. Consumers who cannot
+reach GitHub's attestation API (air-gapped environments, mirrored
+infrastructure, etc.) can download both the tarball and the sidecar
+from the GitHub Release page and pass the bundle to
+`gh attestation verify` via the `--bundle` flag:
+
+```bash
+gh attestation verify ts-migrate-mongoose-X.Y.Z.tgz \
+  --bundle ts-migrate-mongoose-X.Y.Z.tgz.sigstore.json \
+  --repo ilovepixelart/ts-migrate-mongoose \
+  --signer-workflow ilovepixelart/ts-migrate-mongoose/.github/workflows/publish.yaml
+```
+
+With `--bundle` set, `gh attestation verify` does not query the
+GitHub attestation store at all — it verifies the local file against
+the public Sigstore instance. The trust model is identical to the
+online check; only the attestation-retrieval step differs.
 
 Independent supply-chain trust signals for this project (Scorecard,
 OpenSSF Best Practices, Socket.dev, SonarCloud) are published via

--- a/src/commander.ts
+++ b/src/commander.ts
@@ -188,7 +188,7 @@ const formatHelp = (): string => {
 
   const optEntries = (Object.entries(optionDefs) as [string, OptionDef][]).map(([name, opt]) => {
     const short = opt.short ? `-${opt.short}, ` : '    '
-    const arg = opt.arg ? ' ' + opt.arg : ''
+    const arg = opt.arg ? ` ${opt.arg}` : ''
     const long = `--${name}${arg}`
     return { flag: `  ${short}${long}`, description: opt.description }
   })


### PR DESCRIPTION
## Summary

[SLSA v1.0's distributing-provenance guidance](https://slsa.dev/spec/v1.0/distributing-provenance) says producers **MUST** publish attestations in at least one place and **SHOULD** publish in more than one. After PR #480 migrated to `actions/attest@v4` we had two channels — npm registry provenance and GitHub's native attestation store. This adds the third: the same Sigstore bundle attached to the GitHub Release as a sidecar asset.

### The three channels (from 5.3.1+)

| # | Channel | Mechanism | Consumer verification |
|---|---|---|---|
| 1 | npm registry provenance | `publishConfig.provenance: true` → `npm publish --provenance` | `npm audit signatures` |
| 2 | GitHub native attestation store | `actions/attest@v4` | `gh attestation verify --repo …` |
| 3 | **Release asset (new)** | `gh release upload <tarball>.sigstore.json` | `gh attestation verify --bundle <file>` (offline) |

### Implementation

`actions/attest` exposes the locally-generated bundle via its `bundle-path` output. A new `Attach attestation bundle to release` step copies that file under a Scorecard-friendly filename and uploads it with `gh release upload`:

```yaml
- name: Attest build provenance
  id: attest
  uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
  with:
    subject-path: ${{ steps.pack.outputs.tarball-name }}

- name: Attach attestation bundle to release
  env:
    GH_TOKEN: ${{ github.token }}
    BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
    TARBALL: ${{ steps.pack.outputs.tarball-name }}
    RELEASE_TAG: ${{ github.event.release.tag_name }}
  run: |
    set -euo pipefail
    asset="${TARBALL}.sigstore.json"
    cp "$BUNDLE_PATH" "$asset"
    gh release upload "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY" --clobber
```

Requires `contents: write` added to the build job permissions (was `contents: read`).

### Why this matters

1. **SLSA v1.0 SHOULD guidance.** Going from 2 channels to 3 moves us from "meets MUST, doesn't meet SHOULD" to "meets both."
2. **Offline verification path.** Consumers on air-gapped or mirrored infrastructure can now download the tarball + `.sigstore.json` from the Release page and run `gh attestation verify --bundle <file>` without touching GitHub's attestation API. Same Sigstore public instance, same trust model, different retrieval.
3. **OpenSSF Scorecard `Signed-Releases` detection.** Scorecard's check inspects release assets directly and looks for recognized extensions (`*.sigstore.json` is on its list). Before this change it found nothing on `5.3.0` even though the attestation existed in GitHub's store, scoring `-1/10`. After this change — once enough new releases are cut — the check will climb. This is a side effect, not the motivation.

### Version boundary

The SECURITY.md update is explicit about which versions have which channels:

- **`5.2.0`** — predates the hardened pipeline entirely. No provenance in any channel.
- **`5.3.0`** — released under `actions/attest@v4` but before this sidecar step. Has channels 1 (npm) and 2 (GitHub attestation store), no release-asset sidecar.
- **`5.3.1+`** — all three channels.

Consumers auditing a specific version can confirm which pipeline it was built under by looking at the release page: `.sigstore.json` asset → `5.3.1+`; presence in the [attestation store](https://github.com/ilovepixelart/ts-migrate-mongoose/attestations) without sidecar → `5.3.0`; absence from both → `5.2.0` or earlier.

### Trust model (unchanged)

The sidecar file is **byte-identical** to the bundle in GitHub's attestation store. Verification uses the public Sigstore instance either way. The `--bundle` flag tells `gh attestation verify` to skip the attestation API fetch and use the local file, nothing else changes about the verification path. `--signer-workflow` still pins the verification to the exact workflow file.

## Test plan

- [x] `npm run type:check`
- [x] `npm run biome`
- [x] YAML lint (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] First release under the updated pipeline (`5.3.1`) — verifies the `Attach attestation bundle to release` step runs successfully, the `.sigstore.json` asset appears on the GitHub Release, and `gh attestation verify --bundle` works end-to-end against the published bundle