### PR TITLE
Rename release-asset sidecar to .intoto.jsonl for Scorecard 10/10

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,13 +69,21 @@ jobs:
           subject-path: ${{ steps.pack.outputs.tarball-name }}
 
       - name: Attach attestation bundle to release
-        # SLSA v1.0 recommends publishing provenance in more than one channel.
+        # SLSA v1.2 recommends publishing provenance in more than one channel.
         # actions/attest already uploaded the bundle to GitHub's native attestation
-        # store and npm will ship an npm-registry provenance attestation via
+        # store and npm ships an npm-registry provenance attestation via
         # publishConfig.provenance: true. This third channel puts the same Sigstore
-        # bundle on the GitHub Release as a sidecar asset (<tarball>.sigstore.json)
-        # so consumers who rely on the classic "signed release assets" pattern —
-        # including OpenSSF Scorecard's Signed-Releases check — can find it too.
+        # bundle on the GitHub Release as a sidecar asset so consumers who rely on
+        # the classic "signed release assets" pattern can find it.
+        #
+        # File extension is `.intoto.jsonl` even though the content is a Sigstore
+        # bundle (application/vnd.dev.sigstore.bundle.v0.3+json). This matches the
+        # established convention used by slsa-github-generator and documented by
+        # OpenSSF Scorecard's Signed-Releases check: Scorecard treats `.intoto.jsonl`
+        # as the SLSA provenance file (max score 10/10) and the other recognised
+        # extensions (`.sig`, `.sigstore.json`, etc.) as generic signatures (8/10).
+        # The bundle format is the same either way; `gh attestation verify --bundle`
+        # parses the content regardless of filename.
         env:
           GH_TOKEN: ${{ github.token }}
           BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
@@ -83,7 +91,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          asset="${TARBALL}.sigstore.json"
+          asset="${TARBALL}.intoto.jsonl"
           cp "$BUNDLE_PATH" "$asset"
           gh release upload "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY" --clobber
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -146,29 +146,43 @@ release:
    and verifiable through `gh attestation verify` — no extra tooling
    install required by consumers who already have the `gh` CLI.
 3. **GitHub Release asset** — the same Sigstore bundle is copied to
-   a sidecar file named `<tarball>.sigstore.json` and attached to
+   a sidecar file named `<tarball>.intoto.jsonl` and attached to
    the GitHub Release via `gh release upload` in a follow-up step of
    the same job. This is the "classic" distribution channel used by
    tools that inspect release assets directly (including
-   OpenSSF Scorecard's `Signed-Releases` check).
+   OpenSSF Scorecard's `Signed-Releases` check, which recognises
+   `.intoto.jsonl` as the SLSA provenance indicator). The file
+   extension is a legacy convention; the content is a Sigstore
+   bundle (`application/vnd.dev.sigstore.bundle.v0.3+json`) — the
+   same format `slsa-github-generator` has shipped under that name
+   for years, and `gh attestation verify --bundle` parses it
+   regardless of filename.
 
 **Status:** the hardened pipeline was introduced in the 5.2.x
 maintenance series but the three-channel attestation story (above)
-is complete only **from `5.3.1` onward**:
+reaches its final shape only **from `5.3.2` onward**:
 
 - `5.2.0` predates the new `publish.yaml` entirely — no provenance
   in any channel.
 - `5.3.0` was released under `actions/attest@v4` but before the
   release-asset sidecar step was added, so it has channels 1 and 2
-  (npm registry + GitHub attestation store) but no
-  `.sigstore.json` asset on the release.
-- `5.3.1+` has all three channels.
+  (npm registry + GitHub attestation store) but no release-asset
+  sidecar.
+- `5.3.1` was the first release with all three channels. The
+  sidecar was initially shipped under the `.sigstore.json`
+  extension, which OpenSSF Scorecard recognises as a generic
+  signature (score 8/10) rather than a SLSA provenance file.
+- `5.3.2+` ships the same Sigstore bundle under the
+  `.intoto.jsonl` extension so Scorecard's `Signed-Releases` check
+  can detect it as SLSA provenance (score 10/10). The content is
+  unchanged.
 
 Consumers auditing a specific version can confirm which pipeline
-it was built under by looking at the release: a `.sigstore.json`
-asset means `5.3.1+` shape; presence in
+it was built under by looking at the release: a `.intoto.jsonl`
+asset means `5.3.2+`; a `.sigstore.json` asset means `5.3.1` as
+originally shipped; presence in
 [the attestation store](https://github.com/ilovepixelart/ts-migrate-mongoose/attestations)
-without the sidecar asset means `5.3.0`; absence from both means
+without any sidecar asset means `5.3.0`; absence from both means
 `5.2.0` or earlier.
 
 ### Dev-environment isolation
@@ -244,16 +258,17 @@ store is accessible without authentication.
 **Offline check (classic release-asset path):**
 
 For `5.3.1+` releases, the same Sigstore bundle is also attached to
-the GitHub Release as a sidecar file named
-`ts-migrate-mongoose-X.Y.Z.tgz.sigstore.json`. Consumers who cannot
-reach GitHub's attestation API (air-gapped environments, mirrored
-infrastructure, etc.) can download both the tarball and the sidecar
-from the GitHub Release page and pass the bundle to
+the GitHub Release as a sidecar file — named
+`ts-migrate-mongoose-X.Y.Z.tgz.intoto.jsonl` from `5.3.2` onward,
+or `…tgz.sigstore.json` on the initial `5.3.1` release. Consumers
+who cannot reach GitHub's attestation API (air-gapped environments,
+mirrored infrastructure, etc.) can download both the tarball and
+the sidecar from the GitHub Release page and pass the bundle to
 `gh attestation verify` via the `--bundle` flag:
 
 ```bash
 gh attestation verify ts-migrate-mongoose-X.Y.Z.tgz \
-  --bundle ts-migrate-mongoose-X.Y.Z.tgz.sigstore.json \
+  --bundle ts-migrate-mongoose-X.Y.Z.tgz.intoto.jsonl \
   --repo ilovepixelart/ts-migrate-mongoose \
   --signer-workflow ilovepixelart/ts-migrate-mongoose/.github/workflows/publish.yaml
 ```


### PR DESCRIPTION
## Summary

Rename the release-asset sidecar file from `<tarball>.sigstore.json` to `<tarball>.intoto.jsonl` — **content unchanged**, only the filename extension differs. This unlocks the Scorecard `Signed-Releases` 10/10 score and matches what sibling `ts-patch-mongoose` already produces.

## Why

I analysed sibling `ts-patch-mongoose-4.0.0.tgz.intoto.jsonl` (produced by `slsa-github-generator`) byte-for-byte against our `ts-migrate-mongoose-5.3.1.tgz.sigstore.json` (produced by `actions/attest@v4`) and confirmed they are **structurally identical**:

| Property | Sibling `.intoto.jsonl` | Ours `.sigstore.json` |
|---|---|---|
| Format | Single-line JSON | Single-line JSON |
| `mediaType` | `application/vnd.dev.sigstore.bundle.v0.3+json` | **same** |
| Top-level keys | `mediaType`, `verificationMaterial`, `dsseEnvelope` | **same** |
| Wrapped content | SLSA v1 build provenance in in-toto statement inside DSSE envelope | **same** |

The `.intoto.jsonl` extension is a legacy naming convention that `slsa-github-generator` has shipped under for years. The content is **not** a "JSON Lines file of in-toto statements" in any literal sense — it's a single-line Sigstore bundle — but the extension is the established way to label a Sigstore-wrapped SLSA provenance file for tools that inspect release assets by filename.

**OpenSSF Scorecard's scoring rubric**, confirmed against the [source-of-truth doc](https://github.com/ossf/scorecard/blob/c22063e786c11f9dd714d777a687ff7c4599b600/docs/checks.md#signed-releases), is purely filename-based:

| Extension | Scorecard score |
|---|---|
| `.minisig`, `.asc`, `.sig`, `.sign`, `.sigstore`, `.sigstore.json` | **8/10** (generic signature) |
| `.intoto.jsonl` | **10/10** (SLSA provenance) |

With the previous `.sigstore.json` naming we capped at 8/10; with `.intoto.jsonl` we match sibling's current 10/10 and the full set of tools that detect SLSA provenance via the classic release-asset channel.

## Trust model (unchanged)

- `gh attestation verify --bundle <file>` parses the content regardless of filename, so the consumer verification flow documented in SECURITY.md is unchanged.
- `--signer-workflow` still pins verification to the exact workflow file.
- The file is bit-for-bit the same Sigstore bundle that lives in GitHub's attestation store and the same shape that `slsa-github-generator` has shipped under `.intoto.jsonl` for years.

## Workflow diff

```diff
-          asset="${TARBALL}.sigstore.json"
+          asset="${TARBALL}.intoto.jsonl"
```

Plus inline comment rewrite explaining the extension-vs-content distinction so the next reviewer doesn't chase the same rabbit hole.

## SECURITY.md updates

- Channel 3 description now names the sidecar `.intoto.jsonl`, cites Scorecard's scoring rubric, and explains that the extension is a legacy naming convention.
- Version boundary extended:
  - `5.2.0` — no provenance anywhere
  - `5.3.0` — channels 1+2 only (no release sidecar)
  - `5.3.1` — first release with all three channels, sidecar shipped as `.sigstore.json` (scores 8/10)
  - **`5.3.2+`** — sidecar shipped as `.intoto.jsonl` (scores 10/10)
- Offline verification example updated to reference the new extension with a historical note for `5.3.1`.

## Test plan

- [x] YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] `npm run biome`
- [ ] `5.3.2` release under the updated pipeline — verifies the `Attach attestation bundle to release` step produces `ts-migrate-mongoose-5.3.2.tgz.intoto.jsonl`
- [ ] Next Scorecard scan sees the `.intoto.jsonl` asset and moves `Signed-Releases` from 8 (projected) to 10/10

**Note:** `5.3.1` will continue to carry its original `.sigstore.json` sidecar. If Scorecard's last-N-releases check penalises us for the 5.3.1 shape in the interim, we can backfill it with a manual `gh release upload v5.3.1 ts-migrate-mongoose-5.3.1.tgz.intoto.jsonl` after this PR merges — the bundle file we already have locally in `/tmp/attest-verify/` is exactly the content needed.