### PR TITLE
Scorecard: re-score after successful Publish runs

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -13,6 +13,14 @@ on:
     - cron: '32 7 * * 1'
   push:
     branches: [ "main" ]
+  # Re-score after every successful Publish run so the Signed-Releases check
+  # sees the freshly attached release-asset sidecars. Without this, the
+  # Scorecard scan from the pre-release push to main races the publish.yaml
+  # workflow and captures a stale state where release assets aren't yet
+  # uploaded. See the accepted-findings rationale in SECURITY.md.
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -21,6 +29,11 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # When triggered by workflow_run (after Publish), only proceed if the
+    # Publish run actually succeeded. No point scoring a failed release.
+    # For all other triggers (push, schedule, branch_protection_rule) the
+    # condition evaluates true and the job runs normally.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
## Summary

Close the race condition between the pre-release \`push: main\` Scorecard scan and the \`publish.yaml\` workflow that attaches release-asset sidecars.

## What we observed on v5.3.2

\`\`\`
22:10:06Z  v5.3.2 release tag created
22:10:06Z  publish.yaml v5.3.2 run started
22:10:13Z  Scorecard scan ran against the merge commit that landed
           the dual-sidecar work, triggered by the pre-release push
           to main — 7 seconds before publish.yaml finished
~22:11:00Z publish.yaml finished uploading .sigstore.json and
           .intoto.jsonl to the v5.3.2 release
\`\`\`

The scan saw v5.3.2 as a release with zero attached assets (the asset-upload step hadn't run yet), filtered it out as source-only, and scored against v5.3.1's single \`.sigstore.json\` — capping \`Signed-Releases\` at **8/10**. The new v5.3.2 \`.intoto.jsonl\` was invisible to that scan even though it landed on the release 47 seconds later.

## The fix

Add a \`workflow_run\` trigger so Scorecard re-scans after every successful Publish run. That's the only moment when the release state is fully settled: tarball on npm, assets on the release, attestation in GitHub's store, tlog entry in Rekor.

\`\`\`yaml
on:
  branch_protection_rule:
  schedule:
    - cron: '32 7 * * 1'
  push:
    branches: ["main"]
  workflow_run:
    workflows: ["Publish"]
    types: [completed]
\`\`\`

Plus an \`if:\` guard on the analysis job so workflow_run-triggered scans only run when the upstream Publish succeeded:

\`\`\`yaml
if: \${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
\`\`\`

For all other triggers (\`push\`, \`schedule\`, \`branch_protection_rule\`) the guard evaluates true and the job runs as before.

## Why keep \`push: main\`

It covers a different event than \`workflow_run: Publish\`:

- **\`push: main\`** — every merge to main, including between releases. Catches workflow-file changes, new accepted-findings in SECURITY.md, package.json changes, etc. Without it, Scorecard would go stale for days between releases.
- **\`workflow_run: Publish\`** — only fires on release tags. Only trigger that sees the post-upload release-asset state.

They're complementary, not overlapping.

## Trigger matrix after this change

| Trigger | Fires on | Purpose |
|---|---|---|
| \`branch_protection_rule\` | Ruleset changes | Re-check Branch-Protection |
| \`schedule\` (Mon 07:32 UTC) | Weekly | Belt-and-braces fallback, externally-changing checks |
| \`push: main\` | Every merge | Catches between-release changes |
| **\`workflow_run: Publish\`** (new) | After every Publish | Fresh Signed-Releases scoring post-release |

## Test plan

- [x] YAML parses
- [ ] Next release (\`v5.3.3\` or whichever comes next) — observe that a second Scorecard run fires ~1 minute after the release tag, reads the just-attached \`.intoto.jsonl\`, and updates \`Signed-Releases\` to **10/10**

## Trade-offs

- **Cost:** one extra Scorecard run per release (~1 min, negligible).
- **Failure mode:** if publish.yaml fails, the \`if:\` guard skips the re-score. If publish.yaml succeeds but Scorecard itself fails, that shows as a red workflow in the Actions tab — visible enough to fix.
- **No privilege change:** \`workflow_run\` jobs run with the permissions declared in \`scorecard.yaml\`, not the triggering workflow's permissions.